### PR TITLE
Fix/csv importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.2.0
+### 0.3.0
 1. now supporting filters on columns with multiple values and a legend component.
 
 2. If you are updating from any previous versions - **breaking change**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ### 0.3.0
+1. Fixes bug in csv imports
+2. Allows displaying methods in tables and csv exports
+
+### 0.2.0
 1. now supporting filters on columns with multiple values and a legend component.
 
 2. If you are updating from any previous versions - **breaking change**

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Have now added a config for where the 'show' page url should be - this also migh
 
 ## How to Use the WcmcComponents CSV Importer
 
-Note: When importing a belongs_to or has_and_belongs_to_many association, if a record is not found based
+Note: When importing a belongs_to association, if a record is not found based
 on the csv strings being parsed, the association is set as nil. Therefore, you have to make sure to create 
 database records for the associations before importing a csv.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Create an intializer e.g. in config/initializers/table.rb containing the mapping
 TODO: I think I should be able to figure these mappings automagically from the mount line but can't make this work (yet!)
 Have now added a config for where the 'show' page url should be - this also might be able to be pulled out of routes with a bit of patience
 
-## How to Use the WcmcComponents Table Engine
+## How to Use the WcmcComponents CSV Importer
 
 ### Setting up your class
 
@@ -98,9 +98,11 @@ end
 ### Importing the CSV data
 
 CSV files must be located in the lib/data/seeds directory, or the test/seeds directory for testing.
-Call the import with, e.g. ```Project.import```
 
-With no arguments the importer will attempt to find a file with the snakecase version of the class name.
+Start the import with, e.g. ```Project.import```
+
+With no arguments the importer will attempt to find a CSV with the snakecase version of the class name.
+
 You can specify a different file name, and specify the encoding of the CSV:
 ```Project.import('special_projects', 'iso-8859-1:utf-8')```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Have now added a config for where the 'show' page url should be - this also migh
 
 ## How to Use the WcmcComponents CSV Importer
 
-### Setting up your class
+### Setting up your class for import
 
 ```
 require 'wcmc_components'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# README (Style guide guide)
+# wcmc_components
+
+Features:
+- Import csv files as database records
+- Add filterable tables for the UI, with modals and csv export
 
 ## Getting up and running
 * bundle
@@ -10,7 +14,7 @@ Terminal 1:
 Terminal 2:
 * webpack-dev-server
 
-## Runnning Tests
+## Running Tests
 Terminal 3:
 * yarn test
 
@@ -40,9 +44,24 @@ In the model you want to display in a filter table add
 * include WcmcComponents::Filterable
 
 and optionally configure columns using the table_column method, e.g.
-*   table_column :created_at, title: 'First Date'
+*   table_attr :created_at, title: 'First Date'
+
+```
+# Add this method for each of the fileds you want to display in the table
+table_attr(
+  :bip_indicator,            # the model attribute, either a database field or method on the model
+  title: 'BIP Indicator',    # the title that will appear in the tables, modals, and csv files
+  filter_on: true,           # if true, attribute will be filterable in UI table. Will only filter database fields
+  type: 'single',            # if 'single', this is a field on this class, if 'multiple' it will take the :name field from associated records
+  show_in_table: false,      # Show or hide the field in the UI table
+  show_in_modal: true        # Show or hide the field in the modal
+  show_in_csv: true          # Show or hide the table in the csv export. Default is null.  If null,
+)                            # field will be shown if either show_in_table or show_in_modal are true
+
+```
 
 see app/models/country.rb as an example
+
 
 ### configure the engine
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Also, if verbose is set to true for yarn test, often console logs are overwritte
 
 in Gemfile add either:
 
-* gem 'wcmc_components', '~> 0.2.1', source: "https://gem-server.unep-wcmc.org/"
+* gem 'wcmc_components', '~> 0.3.0', source: "https://gem-server.unep-wcmc.org/"
 
 or to use local code cloned into web-components
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Have now added a config for where the 'show' page url should be - this also migh
 
 ## How to Use the WcmcComponents CSV Importer
 
+Note: When importing a belongs_to or has_and_belongs_to_many association, if a record is not found based
+on the csv strings being parsed, the association is set as nil. Therefore, you have to make sure to create 
+database records for the associations before importing a csv.
+
 ### Setting up your class for import
 
 ```

--- a/wcmc_components/lib/wcmc_components/filterable.rb
+++ b/wcmc_components/lib/wcmc_components/filterable.rb
@@ -30,6 +30,18 @@ module WcmcComponents
         table_attrs.select { |_k, v| v[:show_in_table] || v[:show_in_modal] } || {}
       end
 
+      def csv_items
+        table_attrs.select do |_k, v|
+          if v[:show_in_csv] == true
+            true
+          elsif v[:show_in_csv] == false
+            false
+          else
+            v[:show_in_table] || v[:show_in_modal]
+          end
+        end || {}
+      end
+
       def table_attrs
         @table_attrs ||= {}
       end
@@ -69,7 +81,7 @@ module WcmcComponents
           }
 
           table_attrs.each_key do |col|
-            item_j[col.to_s] = item[col]
+            item_j[col.to_s] = item.send(col)
           end
 
           item_j
@@ -100,7 +112,7 @@ module WcmcComponents
           
           # build headers for CSV from the column titles on the page
           headers = ['Id']
-          table_cols_and_modal_items.each do |key,col|
+          csv_items.each do |key,col|
             headers << col[:title]
           end
           csv_line << headers.flatten
@@ -109,10 +121,10 @@ module WcmcComponents
           items.each do |item|
             row = []
             row << item.id
-            table_cols_and_modal_items.each do |key,col|
+            csv_items.each do |key,col|
               case col[:type]
               when "single"
-                row << item[key]
+                row << item.send(key)
               when "multiple"
                 row << item.send(key.to_s.pluralize).map(&:name).join('; ')
               end
@@ -143,7 +155,7 @@ module WcmcComponents
               item_j[:cells] << {
                 name: key.to_s,
                 title: col[:title],
-                value: item[key],
+                value: item.send(key),
                 showInTable: col[:show_in_table],
                 showInModal: col[:show_in_modal],
                 legend_on: col[:legend_on]

--- a/wcmc_components/lib/wcmc_components/loadable.rb
+++ b/wcmc_components/lib/wcmc_components/loadable.rb
@@ -58,7 +58,7 @@ module WcmcComponents
 
                   # strip the class_ from front of keys
                   belongs_to_hash.transform_keys! { |key| key.remove k+"_"}
-                  owner = belongs_to_class.find_or_create_by!(belongs_to_hash)
+                  owner = belongs_to_class.find_or_create_by!(belongs_to_hash) unless belongs_to_hash.empty?
                 end
                 row_hash[k] = owner
               end

--- a/wcmc_components/lib/wcmc_components/version.rb
+++ b/wcmc_components/lib/wcmc_components/version.rb
@@ -1,3 +1,3 @@
 module WcmcComponents
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/wcmc_components/lib/wcmc_components/version.rb
+++ b/wcmc_components/lib/wcmc_components/version.rb
@@ -1,3 +1,3 @@
 module WcmcComponents
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Fixes a bug with the csv import

When ```belongs_to_class.find_or_create_by!(belongs_to_hash)``` is called with an empty hash, which happens when there there is no column for that association in the csv, it:
- returns a record if there are some in the db resulting in an incorrect association
- errors if there are no saved records of that class

For some reason ```User.find_or_create_by!({})``` returns a record if there are some in the database.

The change means we don't call ```find_or_create_by!``` if the hash is empty.

Testing:
Easiest way to do this is to:
1. checkout action agenda develop branch
2. reset db but don't run seeds
3. run ```rake import_commitments_and_migrate_data```
4. should error and drop you in a byebug
5. checkout this branch of the gem
6. edit gemfile to use local version
7. run ```rake import_commitments_and_migrate_data``` with no error
