### PR TITLE
Feat/allow methods in tables and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# README (Style guide guide)
+# wcmc_components
+
+Features:
+- Import csv files as database records
+- Add filterable tables for the UI, with modals and csv export
 
 ## Getting up and running
 * bundle
@@ -10,7 +14,7 @@ Terminal 1:
 Terminal 2:
 * webpack-dev-server
 
-## Runnning Tests
+## Running Tests
 Terminal 3:
 * yarn test
 
@@ -40,9 +44,24 @@ In the model you want to display in a filter table add
 * include WcmcComponents::Filterable
 
 and optionally configure columns using the table_column method, e.g.
-*   table_column :created_at, title: 'First Date'
+*   table_attr :created_at, title: 'First Date'
+
+```
+# Add this method for each of the fileds you want to display in the table
+table_attr(
+  :bip_indicator,            # the model attribute, either a database field or method on the model
+  title: 'BIP Indicator',    # the title that will appear in the tables, modals, and csv files
+  filter_on: true,           # if true, attribute will be filterable in UI table. Will only filter database fields
+  type: 'single',            # if 'single', this is a field on this class, if 'multiple' it will take the :name field from associated records
+  show_in_table: false,      # Show or hide the field in the UI table
+  show_in_modal: true        # Show or hide the field in the modal
+  show_in_csv: true          # Show or hide the table in the csv export. Default is null.  If null,
+)                            # field will be shown if either show_in_table or show_in_modal are true
+
+```
 
 see app/models/country.rb as an example
+
 
 ### configure the engine
 

--- a/wcmc_components/lib/wcmc_components/filterable.rb
+++ b/wcmc_components/lib/wcmc_components/filterable.rb
@@ -30,6 +30,18 @@ module WcmcComponents
         table_attrs.select { |_k, v| v[:show_in_table] || v[:show_in_modal] } || {}
       end
 
+      def csv_items
+        table_attrs.select do |_k, v|
+          if v[:show_in_csv] == true
+            true
+          elsif v[:show_in_csv] == false
+            false
+          else
+            v[:show_in_table] || v[:show_in_modal]
+          end
+        end || {}
+      end
+
       def table_attrs
         @table_attrs ||= {}
       end
@@ -69,7 +81,7 @@ module WcmcComponents
           }
 
           table_attrs.each_key do |col|
-            item_j[col.to_s] = item[col]
+            item_j[col.to_s] = item.send(col)
           end
 
           item_j
@@ -100,7 +112,7 @@ module WcmcComponents
           
           # build headers for CSV from the column titles on the page
           headers = ['Id']
-          table_cols_and_modal_items.each do |key,col|
+          csv_items.each do |key,col|
             headers << col[:title]
           end
           csv_line << headers.flatten
@@ -109,10 +121,10 @@ module WcmcComponents
           items.each do |item|
             row = []
             row << item.id
-            table_cols_and_modal_items.each do |key,col|
+            csv_items.each do |key,col|
               case col[:type]
               when "single"
-                row << item[key]
+                row << item.send(key)
               when "multiple"
                 row << item.send(key.to_s.pluralize).map(&:name).join('; ')
               end
@@ -143,7 +155,7 @@ module WcmcComponents
               item_j[:cells] << {
                 name: key.to_s,
                 title: col[:title],
-                value: item[key],
+                value: item.send(key),
                 showInTable: col[:show_in_table],
                 showInModal: col[:show_in_modal],
                 legend_on: col[:legend_on]


### PR DESCRIPTION
Allows displaying methods in filterable tables, modals, and csv exports

Testing:
- check out branch
- in a project that uses this gem, point the gemfile at your local version of this gem with e.g. ```* gem 'wcmc_components', path: '../web-components/wcmc_components'```
- add table_attr for a method in the model
- check it displays in the tables
- check it exports as csv
- check you can prevent it showing in the csv but show it in the table or modal and vice versa 