### PR TITLE
feat: allow updating associated records via the form

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ table_attribute(
 
 see app/models/country.rb as an example
 
+If you want to allow editing associated records via the form you need to add a call to ```add_form_methods_for_associated_records``` in your table classes below the table_attribute method calls.
+TODO: Find a way to do this automatically
+
 Currently, the 'show' button redirects to a show page by default. To make the button open a modal instead you need to override the
 `#table_page_path` method in your model classes: 
 ```

--- a/wcmc_components/app/controllers/wcmc_components/table_controller.rb
+++ b/wcmc_components/app/controllers/wcmc_components/table_controller.rb
@@ -26,10 +26,10 @@ module WcmcComponents
 
     def create
       @table_resource = model_class.new
-      @table_resource.update(modify_params)
+      @table_resource.assign_attributes(modify_params)
 
       if @table_resource.save
-        redirect_to table_path(@table_resource)
+        render :new
       else
         render :new, status: :unprocessable_entity
       end
@@ -44,9 +44,11 @@ module WcmcComponents
       # Identify the resource
       @table_resource = model_class.find(params[:id])
       # Update the resource
-      if @table_resource.update(modify_params)
+      @table_resource.assign_attributes(modify_params)
+
+      if @table_resource.save
         # Redirect (to the show page/index page)
-        redirect_to table_path(@table_resource)
+        render :edit
       else
         render :edit, status: :unprocessable_entity
       end
@@ -80,8 +82,19 @@ module WcmcComponents
   
     def modify_params
       params.require(:table).permit(
-        *@table_resource.form_attributes.keys
+        *params_from_form_attributes
       )
+    end
+
+    def params_from_form_attributes
+      @table_resource.form_attributes.keys.map do |form_attribute|
+        if form_attribute.to_s.split('.').length > 1
+          table_name, attribute_name = form_attribute.to_s.split('.')
+          "#{form_attribute.to_s.split('.')[0].pluralize}_#{form_attribute.to_s.split('.')[1].pluralize}".to_sym
+        else
+          form_attribute
+        end
+      end
     end
   end
 end

--- a/wcmc_components/app/views/wcmc_components/table/_form_field.html.erb
+++ b/wcmc_components/app/views/wcmc_components/table/_form_field.html.erb
@@ -1,11 +1,23 @@
 <div class="form__field">
-  <div class="form__label">
-    <%= form.label form_attribute[0], "#{form_attribute[1][:title]}" %>
+  <% if form_attribute[1][:type] == 'single' %>
+    <div class="form__label">
+      <%= form.label form_attribute[0], "#{form_attribute[1][:title]}" %>
 
-    <% if form_attribute[1].key?(:required) && form_attribute[1][:required] %>
-      <span class="form__required-star">*</span>
-    <% end %>
-  </div>
+      <% if form_attribute[1].key?(:required) && form_attribute[1][:required] %>
+        <span class="form__required-star">*</span>
+      <% end %>
+    </div>
 
-  <%= form.send(form_attribute.dig(1, :form_builder_method), form_attribute[0]) %>
+    <%= form.send(form_attribute.dig(1, :form_builder_method), form_attribute[0]) %>
+  <% else %>
+    <% table_name, table_attribute = form_attribute[0].to_s.split('.') %>
+    <div class="form__label">
+      <%= form.label table_name, "#{form_attribute[1][:title]} - #{table_attribute} (; seperated values)" %>
+
+      <% if form_attribute[1].key?(:required) && form_attribute[1][:required] %>
+        <span class="form__required-star">*</span>
+      <% end %>
+    </div>
+    <%= form.send(form_attribute.dig(1, :form_builder_method), "#{table_name}_#{table_attribute.pluralize}".to_sym) %>
+  <% end %>
 </div>

--- a/wcmc_components/lib/wcmc_components/filterable.rb
+++ b/wcmc_components/lib/wcmc_components/filterable.rb
@@ -40,7 +40,7 @@ module WcmcComponents
           accessor_method_name = "#{table_name}_#{atribute_name.pluralize}"
           self.send(accessor_method_name).split(';').each do |value|
             params = {}
-            params[atribute_name.to_sym] = value
+            params[atribute_name.to_sym] = value.strip
             self.send(table_name) << table_name.classify.constantize.find_or_create_by(params)
           end
         end
@@ -70,7 +70,6 @@ module WcmcComponents
         table_name, atribute_name = name.to_s.split('.')
         accessor_method_name = "#{table_name}_#{atribute_name.pluralize}"
         instance_variable_name = "@#{accessor_method_name}"
-        # instance_variable_set("#{table_name}", nil)
 
         define_method(accessor_method_name) do
           instance_variable_get(instance_variable_name) ||

--- a/wcmc_components/lib/wcmc_components/filterable.rb
+++ b/wcmc_components/lib/wcmc_components/filterable.rb
@@ -34,13 +34,13 @@ module WcmcComponents
       def build_associations
         # Rebuilds associations from the ; separated string of values in the dynamically defined instance variable.
         table_attributes.association_attributes.each do |association_attribute|
-          table_name, atribute_name = association_attribute[0].to_s.split('.')
+          table_name, attribute_name = association_attribute[0].to_s.split('.')
           self.send(table_name).clear
 
-          accessor_method_name = "#{table_name}_#{atribute_name.pluralize}"
+          accessor_method_name = "#{table_name}_#{attribute_name.pluralize}"
           self.send(accessor_method_name).split(';').each do |value|
             params = {}
-            params[atribute_name.to_sym] = value.strip
+            params[attribute_name.to_sym] = value.strip
             self.send(table_name) << table_name.classify.constantize.find_or_create_by(params)
           end
         end
@@ -67,13 +67,13 @@ module WcmcComponents
 
       def define_additional_form_methods_for_association(name)
         # Dynamically define methods to be used for hacking the form to work with multiple associations.
-        table_name, atribute_name = name.to_s.split('.')
-        accessor_method_name = "#{table_name}_#{atribute_name.pluralize}"
+        table_name, attribute_name = name.to_s.split('.')
+        accessor_method_name = "#{table_name}_#{attribute_name.pluralize}"
         instance_variable_name = "@#{accessor_method_name}"
 
         define_method(accessor_method_name) do
           instance_variable_get(instance_variable_name) ||
-          instance_variable_set(instance_variable_name, self.send(table_name).map(&atribute_name.to_sym).join(';'))
+          instance_variable_set(instance_variable_name, self.send(table_name).map(&attribute_name.to_sym).join(';'))
         end
 
         define_method("#{accessor_method_name}=") do |value|


### PR DESCRIPTION
Adds additional methods to the table classes and uses them to rebuild associations from form data

- dynamically define virtual attributes in table models which generate a ; separated string from the associated records using the table and attribute defined in the table_attributes method i.e.: ```:'table.attribute'```
- adds these to the form
- after submit it sets these in the virtual variable
- before save it clears existing associations, splits the ; separated string, and finds or creates the associated record and adds to the records associations